### PR TITLE
chore: Add target dev for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,11 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
+    target-branch: "dev" # Ensures 'main' only receives updates from 'dev' and that after, 'main' will also get a new version for npm.
     directory: "/"
     open-pull-requests-limit: 5
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: "daily"
       time: '10:00'
       timezone: 'Europe/Berlin'
     assignees: ['born3am'] # Assign PRs to a specific user or team


### PR DESCRIPTION
This pull request includes a change to the `.github/dependabot.yml` file to modify the update schedule and target branch for npm dependencies.

Changes to update schedule and target branch:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R6-R10): Changed the `target-branch` to "dev" to ensure that the 'main' branch only receives updates from 'dev' and that 'main' will also get a new version for npm. Updated the schedule interval from "weekly" to "daily" for more frequent updates.