### PR TITLE
chore(deps): update dependabot config splitting dev and main #28

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,33 +1,44 @@
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    target-branch: "dev" # Ensures 'main' only receives updates from 'dev' and that after, 'main' will also get a new version for npm.
-    directory: "/"
+  # Version updates for `dev` branch
+  - package-ecosystem: 'npm'
+    target-branch: 'dev' # Ensures 'main' only receives updates from 'dev', so 'main' reflects all dependency updates and the new package version when merged (useful for npm)
+    directory: '/' # Look for package.json in the root directory
     open-pull-requests-limit: 5
     schedule:
-      interval: "daily"
+      interval: 'daily'
       time: '10:00'
       timezone: 'Europe/Berlin'
-    assignees: ['born3am'] # Assign PRs to a specific user or team
+    assignees: ['born3am']
     commit-message:
-      prefix: "chore" # PR title prefix
-      include: 'scope'
+      prefix: 'chore' # PR title prefix
+      include: 'scope' # Include scope in PR title
     groups:
-      minor-updates:
-        applies-to: version-updates
+      minor-updates: # Group all patch updates together
+        applies-to: 'version-updates' # version-updates or security-updates
         update-types:
-          - "patch" # Group all patch updates together
-    versioning-strategy: increase-if-necessary
+          - 'patch'
+    versioning-strategy: increase-if-necessary # Only bump version if required for compatibility or security
     ignore:
-      - dependency-name: "*"
+      - dependency-name: '*' # Ignore all pre-release versions for stability
         versions:
-        - "alpha"
-        - "beta"
-        - "canary"
-        - "dev"
-        - "experimental"
-        - "legacy"
-        - "next"
-        - "nightly"
+        - 'alpha' # Unstable early-stage development versions
+        - 'beta' # Pre-production versions
+        - 'canary' # Frequently updated testing versions
+        - 'dev' # Developer-only versions
+        - 'experimental' # Experimental versions with high instability
+        - 'legacy' # Deprecated versions
+        - 'next' # Future versions not finalized
+        - 'nightly' # Daily unstable builds
+
+  # Security updates for `main` branch
+  - package-ecosystem: 'npm'
+    directory: '/' # Look for package.json in the root directory
+    schedule:
+      interval: 'daily'
+      time: '11:00'
+      timezone: 'Europe/Berlin'
+    labels:
+      - 'security' # Add a "security" label to these PRs
+    allow:
+      - dependency-type: 'direct' # Prioritize direct dependencies for security updates


### PR DESCRIPTION


* chore(deps): update dependabot configuration splitting dev and main

* chore(deps): change dependabot update schedule from weekly to daily

* chore(deps): fix indentation in dependabot configuration for versioning strategy