### PR TITLE
ci: change dependabot update schedule to monthly on the 10th

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,8 @@ updates:
     package-ecosystem: 'npm'
     open-pull-requests-limit: 5
     schedule:
-      interval: 'daily'
+      interval: 'monthly'
+      day-of-month: 10
       time: '10:00'
       timezone: 'Europe/Berlin'
     assignees: ['born3am']


### PR DESCRIPTION
This pull request includes a change to the `.github/dependabot.yml` file to modify the update schedule for npm dependencies.

Changes to update schedule:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L7-R8): Changed the update interval from 'daily' to 'monthly' and set the day of the month to 10.