### PR TITLE
chore(docs): remove eslint-plugin-deprecation from README (rule was r…

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ The package `@born3am/eslint-config` includes the following **dev-dependencies**
   @eslint/eslintrc
   eslint
   eslint-config-prettier
-  eslint-plugin-deprecation
   eslint-plugin-import
   eslint-plugin-jsx-a11y
   eslint-plugin-prettier


### PR DESCRIPTION
…emoved because it is already being maintained by https://typescript-eslint.io/rules/no-deprecated/