### PR TITLE
ci: Update GitHub Actions and Dependabot Configurations, Remove Redun…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,8 @@
 
 version: 2
 updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
+  - directory: '/' # Look for package.json in the root directory
+    package-ecosystem: 'npm'
     open-pull-requests-limit: 5
     schedule:
       interval: 'monthly'
@@ -25,11 +25,11 @@ updates:
     ignore:
       - dependency-name: '*'
         versions:
-          - 'alpha'
-          - 'beta'
-          - 'canary'
-          - 'dev'
-          - 'experimental'
-          - 'legacy'
-          - 'next'
-          - 'nightly'
+          - 'alpha' # Unstable early-stage development versions
+          - 'beta' # Pre-production versions
+          - 'canary' # Frequently updated testing versions
+          - 'dev' # Developer-only versions
+          - 'experimental' # Experimental versions with high instability
+          - 'legacy' # Deprecated versions
+          - 'next' # Future versions not finalized
+          - 'nightly' # Daily unstable builds


### PR DESCRIPTION
…dant Workflows (#35)

* chore(deps): update dependabot configuration splitting dev and main (#28)

* chore(deps): update dependabot configuration splitting dev and main

* chore(deps): change dependabot update schedule from weekly to daily

* chore(deps): fix indentation in dependabot configuration for versioning strategy

* ci: Improve CI/CD and dependabot (#32)

* chore(deps): refine dependabot configuration for security updates

* chore: update node CI workflows and rename it

* chore: remove unused test script

* chore(deps): revert config assuming dev will be set as default branch (#34)

* chore(deps): fix formatting in dependabot configuration

* chore(deps): specify package ecosystem for dependabot updates